### PR TITLE
Implement GSV line

### DIFF
--- a/NmeaParser.Tests/NmeaLineFactoryTests.cs
+++ b/NmeaParser.Tests/NmeaLineFactoryTests.cs
@@ -103,5 +103,43 @@ namespace NmeaParser.Tests
             Assert.Equal(2.1, gsa.Vdop);
 
         }
+
+        [Fact]
+        public void ParseGsvLine()
+        {
+            const string line = "$GPGSV,2,1,08,01,40,083,46,02,17,308,41,12,07,344,39,14,22,228,45*75";
+            var nmeaMsg = new NmeaLineFactory().ParseLine(line);
+            Assert.Equal(NmeaType.Gsv, nmeaMsg.NmeaType);
+            var gsv = (GsvLine)nmeaMsg;
+
+            Assert.Equal(2, gsv.MessageCount);
+            Assert.Equal(1, gsv.MessageIndex);
+            Assert.Equal(8, gsv.SatelliteCount);
+            Assert.Equal(4, gsv.Satellites.Length);
+
+            //01,40,083,46
+            Assert.Equal(1, gsv.Satellites[0].ID);
+            Assert.Equal(40, gsv.Satellites[0].Elevation);
+            Assert.Equal(83, gsv.Satellites[0].Azimuth);
+            Assert.Equal(46, gsv.Satellites[0].SNR);
+
+            //02,17,308,41
+            Assert.Equal(2, gsv.Satellites[1].ID);
+            Assert.Equal(17, gsv.Satellites[1].Elevation);
+            Assert.Equal(308, gsv.Satellites[1].Azimuth);
+            Assert.Equal(41, gsv.Satellites[1].SNR);
+
+            //12,07,344,39
+            Assert.Equal(12, gsv.Satellites[2].ID);
+            Assert.Equal(7, gsv.Satellites[2].Elevation);
+            Assert.Equal(344, gsv.Satellites[2].Azimuth);
+            Assert.Equal(39, gsv.Satellites[2].SNR);
+
+            //14,22,228,45
+            Assert.Equal(14, gsv.Satellites[3].ID);
+            Assert.Equal(22, gsv.Satellites[3].Elevation);
+            Assert.Equal(228, gsv.Satellites[3].Azimuth);
+            Assert.Equal(45, gsv.Satellites[3].SNR);
+        }
     }
 }

--- a/NmeaParser/FixSatellite.cs
+++ b/NmeaParser/FixSatellite.cs
@@ -1,0 +1,36 @@
+﻿namespace NmeaParser
+{
+    /// <summary>
+    /// Represents a single visible satellite in the fix
+    /// </summary>
+    public class FixSatellite
+    {
+        internal FixSatellite(int id, int elevation, int azimuth, int snr)
+        {
+            ID = id;
+            Elevation = elevation;
+            Azimuth = azimuth;
+            SNR = snr;
+        }
+
+        /// <summary>
+        /// PRN identifier of the satellite
+        /// </summary>
+        public int ID { get; }
+
+        /// <summary>
+        /// Elevation in degrees relative to horizon (-90 to 90)
+        /// </summary>
+        public int Elevation { get; }
+
+        /// <summary>
+        /// Azimuth in degrees relative to true north (0 to 359)
+        /// </summary>
+        public int Azimuth { get; }
+
+        /// <summary>
+        /// Signal to noise ratio in dB
+        /// </summary>
+        public int SNR { get; }
+    }
+}

--- a/NmeaParser/NmeaLineFactory.cs
+++ b/NmeaParser/NmeaLineFactory.cs
@@ -55,6 +55,8 @@ namespace NmeaParser
                     return ParseGll(trimmed);
                 case NmeaType.Gsa:
                     return ParseGsa(trimmed);
+                case NmeaType.Gsv:
+                    return ParseGsv(trimmed);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(nmeaType));
             }
@@ -88,6 +90,11 @@ namespace NmeaParser
             {
                 return NmeaType.Gsa;
             }
+            else if (trimmed.StartsWith(NmeaMessage.GSVCode))
+            {
+                return NmeaType.Gsv;
+            }
+
             return default;
         }
 
@@ -111,6 +118,9 @@ namespace NmeaParser
         private RmcLine ParseRmc(string nmeaLine) => new RmcLine(nmeaLine);
 
         private GllLine ParseGll(string nmeaLine) => new GllLine(nmeaLine);
+
         private GsaLine ParseGsa(string nmeaLine) => new GsaLine(nmeaLine);
+
+        private GsvLine ParseGsv(string nmeaLine) => new GsvLine(nmeaLine);
     }
 }

--- a/NmeaParser/NmeaLines/GsvLine.cs
+++ b/NmeaParser/NmeaLines/GsvLine.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NmeaParser.NmeaLines
+{
+    public class GsvLine : NmeaMessage
+    {
+        public GsvLine(string nmeaLine) : base(NmeaType.Gsv, nmeaLine)
+        {
+            if (message.Length < 6) throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Not enough fields in message: {message.Length} but expecting at least 6.");
+            if (message.Length % 4 != 3) throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Invalid number of fields: {message.Length} but expecting 3 + an integer multiple of 4.");
+
+            MessageCount = int.TryParse(message[0], out int messageCount) ? messageCount : throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Invalid value for field 0: {message[0]}");
+            MessageIndex = int.TryParse(message[1], out int messageIndex) ? messageIndex : throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Invalid value for field 1: {message[1]}");
+            SatelliteCount = int.TryParse(message[2], out int satelliteCount) ? satelliteCount : throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Invalid value for field 2: {message[2]}");
+
+            int i = 3;
+            var satellites = new List<FixSatellite>();
+            while (i < message.Length)
+            {
+                if (!int.TryParse(message[i++], out int id)) throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Invalid value at field {i - i}: {message[i - 1]}");
+                if (!int.TryParse(message[i++], out int elevation)) throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Invalid value for field {i - 1}: {message[i - 1]}");
+                if (!int.TryParse(message[i++], out int azimuth)) throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Invalid value for field {i - 1}: {message[i - 1]}");
+                if (!int.TryParse(message[i++], out int snr)) throw new ArgumentOutOfRangeException(nameof(nmeaLine), $"Invalid value for field {i - 1}: {message[i - 1]}");
+                satellites.Add(new FixSatellite(id, elevation, azimuth, snr));
+            }
+            Satellites = satellites.ToArray();
+        }
+
+        /// <summary>
+        /// Number of messages needed for full data
+        /// </summary>
+        public int MessageCount { get; }
+
+        /// <summary>
+        /// Message index in group
+        /// </summary>
+        public int MessageIndex { get; }
+
+        /// <summary>
+        /// Number of satellites in view
+        /// </summary>
+        public int SatelliteCount { get; }
+
+        /// <summary>
+        /// Satellite data in this message
+        /// </summary>
+        public FixSatellite[] Satellites { get; }
+    }
+}

--- a/NmeaParser/NmeaLines/NmeaMessage.cs
+++ b/NmeaParser/NmeaLines/NmeaMessage.cs
@@ -9,6 +9,7 @@
         internal const string VTGCode = "VTG";
         internal const string GllCode = "GLL";
         internal const string GsaCode = "GSA";
+        internal const string GSVCode = "GSV";
 
         internal static readonly NmeaMessage Empty = new NmeaMessage();
 

--- a/NmeaParser/NmeaLines/NmeaType.cs
+++ b/NmeaParser/NmeaLines/NmeaType.cs
@@ -9,6 +9,7 @@
         Gga,
         Vtg,
         Gll,
-        Gsa
+        Gsa,
+        Gsv,
     }
 }


### PR DESCRIPTION
References #7 

This does not add GSV support to SystemState.

The GSV messages arrive in a sequence (typically one right after the other, in the correct order, but we have to be able to support this not happening). Each message contains data for up to 4 satellite vehicles. These must then be merged into a single collection to be handed back to the user. Here's my idea for a flow to do this:

1. Start with an empty collection of satellite data objects and an empty set of received indexes.
2. When the first GSV message arrives:
    1. Capture the index and count so we know how many messages we can expect.
    2. Add the parsed satellite data from this message to the collection and mark the index as received.
3. When each subsequent message arrives:
    1. If the message is a duplicate index for the current group, discard it.
    2. Otherwise, merge the parsed satellite data into the collection and mark the index as received.
    3. If we have received all the indexes we are expecting, save the satellite collection to the system state and clear the temporary collections for the next run. Restart at 1.
